### PR TITLE
Enhance profiles

### DIFF
--- a/prompt_templates/monolithic.yaml
+++ b/prompt_templates/monolithic.yaml
@@ -5,6 +5,7 @@ template_type: monolithic
 # These variables are used to process Auto-GPT's input array of messages into a string
 strip_messages_from_end: 0        # Only used when an RP prompt is sent to the LLM
 send_as: "System"               # The name to be used when speaking to the LLM
+ai_name: "AI"                   # Chat attribution to the AI, is typically different ai_setting sname
 
 # This text preceeds the LLM prompt. It is non-standard but may be useful to you.
 prescript: ""

--- a/src/auto_gpt_text_gen_plugin/client.py
+++ b/src/auto_gpt_text_gen_plugin/client.py
@@ -85,12 +85,11 @@ class Client:
 
             # Debug
             logger.debug(
-                f"{Fore.LIGHTRED_EX}Auto-GPT-Text-Gen-Plugin:{Fore.RESET} Got response:\n{response_json}\n\n"
+                f"{Fore.LIGHTRED_EX}Auto-GPT-Text-Gen-Plugin:{Fore.RESET} Got API response:\n{response_json}\n\n"
             )
 
             # Return
             text_response = response_json['results'][0]['text']
-            text_response = self.prompt_manager.remove_whitespace(text_response)
             text_response = self.prompt_manager.reshape_response(text_response)
             logger.debug(
                 f"{Fore.LIGHTRED_EX}Auto-GPT-Text-Gen-Plugin:{Fore.RESET} Returning response:\n {text_response}\n"

--- a/src/auto_gpt_text_gen_plugin/default_prompt.py
+++ b/src/auto_gpt_text_gen_plugin/default_prompt.py
@@ -22,3 +22,17 @@ class DefaultPrompt(PromptEngine):
         """
 
         return self.messages_to_conversation(messages, 'User: ')
+    
+
+    def reshape_response(self, message):
+        """
+        Pass-back message as a dictionary.
+        
+        Args:
+            message (str): The message to reshape.
+            
+        Returns:
+            dict: The message as a dictionary.
+        """
+
+        return message

--- a/src/auto_gpt_text_gen_plugin/default_prompt.py
+++ b/src/auto_gpt_text_gen_plugin/default_prompt.py
@@ -21,4 +21,4 @@ class DefaultPrompt(PromptEngine):
             str: String representation of the messages.
         """
 
-        return self.messages_to_conversation(messages, self.USER_NAME)
+        return self.messages_to_conversation(messages, 'User: ')

--- a/src/auto_gpt_text_gen_plugin/monolithic_prompt.py
+++ b/src/auto_gpt_text_gen_plugin/monolithic_prompt.py
@@ -27,8 +27,20 @@ class MonolithicPrompt(PromptEngine):
 
         # Prime the variables
         message_string = ''
-        user_name = self.get_user_name() + ': '
 
+        user_name = self.get_user_name()
+        if user_name not in ['', None, 'None'] and len(user_name) > 0:
+            user_name += ': '
+        elif user_name == None:
+            user_name = ''
+        
+        chat_name = self.get_ai_chat_name()
+        # If chat_name isn't empty, add a colon and space
+        if chat_name not in ['', None, 'None'] and len(chat_name) > 0:
+            chat_name += ': '
+        elif chat_name == None:
+            chat_name = ''
+        
         if not self.is_ai_system_prompt(self.original_system_msg):
             logger.debug(f"{Fore.LIGHTRED_EX}Auto-GPT-Text-Gen-Plugin:{Fore.RESET} The system message is not an agent prompt, returning original message\n\n")
             return self.messages_to_conversation(messages, user_name)
@@ -44,12 +56,16 @@ class MonolithicPrompt(PromptEngine):
         message_string += self.get_ai_critique()
         message_string += self.get_response_format()
         message_string = self.get_profile_attribute('prescript') + message_string
-        message_string += self.get_profile_attribute('postscript') + '\n\n'
 
+        message_string += '[Begin History]\n\n'
         # Add all the other messages
         end_strip = self.get_end_strip()
         message_string += self.messages_to_conversation(messages[1:-end_strip], user_name)
-        message_string += self.get_ai_chat_name() + ': '
+        message_string += chat_name
+
+        message_string += '[End History]\n\n'
+
+        message_string += self.get_profile_attribute('postscript')
 
         return message_string
     

--- a/src/auto_gpt_text_gen_plugin/monolithic_prompt.py
+++ b/src/auto_gpt_text_gen_plugin/monolithic_prompt.py
@@ -61,9 +61,8 @@ class MonolithicPrompt(PromptEngine):
         # Add all the other messages
         end_strip = self.get_end_strip()
         message_string += self.messages_to_conversation(messages[1:-end_strip], user_name)
-        message_string += chat_name
-
         message_string += '[End History]\n\n'
+        message_string += chat_name
 
         message_string += self.get_profile_attribute('postscript')
 

--- a/src/auto_gpt_text_gen_plugin/monolithic_prompt.py
+++ b/src/auto_gpt_text_gen_plugin/monolithic_prompt.py
@@ -49,7 +49,7 @@ class MonolithicPrompt(PromptEngine):
         # Add all the other messages
         end_strip = self.get_end_strip()
         message_string += self.messages_to_conversation(messages[1:-end_strip], user_name)
-        message_string += self.get_agent_name() + ': '
+        message_string += self.get_ai_chat_name() + ': '
 
         return message_string
     

--- a/src/auto_gpt_text_gen_plugin/prompt_engine.py
+++ b/src/auto_gpt_text_gen_plugin/prompt_engine.py
@@ -185,7 +185,7 @@ class PromptEngine:
 
         goals_list = ''
         for i, goal in enumerate(self.ai_config.ai_goals):
-            goals_list += f"{i+1}. {goal}\n"
+            goals_list += f"{i+1}. {goal.strip()}\n"
 
         return str(goals_list).replace('\\n', '\n')
     
@@ -379,7 +379,7 @@ class PromptEngine:
 
         response += self.get_profile_attribute('lead_in', 'strings')
         response += self.get_agent_name() + ', '
-        response += self.get_agent_role() + ' '
+        response += self.get_agent_role()
         response += self.get_profile_list_as_line('general_guidance', 'strings')
         response += self.get_profile_attribute('os_prompt', 'strings')
         response += self.extract_from_original(self.regex_os)

--- a/src/auto_gpt_text_gen_plugin/prompt_engine.py
+++ b/src/auto_gpt_text_gen_plugin/prompt_engine.py
@@ -8,6 +8,23 @@ class PromptEngine:
 
     def __init__(self):
 
+        # Constants
+        self.RESPONSE_OBJECT = {
+            'thoughts': {
+                "text": "",
+                "reasoning": "",
+                "plan": "",
+                "criticism": "",
+                "speak": ""
+            },
+            "command": {
+                "name": "",
+                "args": {
+                    "arg name": ""
+                }
+            }
+        }
+
         # Pull-in from Auto-GPT
         self.prompt_generator = PromptGenerator()
         self.config = Config()
@@ -493,3 +510,52 @@ class PromptEngine:
             response += attribution + clean_message + '\n\n'
 
         return str(response)
+    
+
+    def match_prop(self, srctext, regexp) -> str:
+        """
+        Match a property named tag using a regular expression.
+        
+        Args:
+            srctext (str): The text to inspect
+            regexp (str): The regular expression to use.
+            
+        Returns:
+            str: The matched property.
+        """
+
+        response = ''
+
+        srctext = self.strip_newlines(srctext)
+        srctext = self.remove_whitespace(srctext)
+        regex_result = re.search(regexp, srctext)
+        if regex_result is not None:
+            try:
+                response = regex_result.group(1)
+            except:
+                response = ''
+
+        return response
+    
+
+    def recover_json_response(self, message:str) -> dict:
+        """
+        Recover a JSON response from a message.
+        
+        Args:
+            message (str): The message to recover the JSON from.
+            
+        Returns:
+            str: The JSON response.
+        """
+
+        response = self.RESPONSE_OBJECT.copy()
+
+        response['thoughts']['text'] = self.match_prop(message, r"[\"']text[\"']\s*:\s*[\"']((?:[^\"\\]|\\.)*)[\"']")
+        response['thoughts']['reasoning'] = self.match_prop(message, r"[\"']reasoning[\"']\s*:\s*[\"']((?:[^\"\\]|\\.)*)[\"']")
+        response['thoughts']['plan'] = self.match_prop(message, r"[\"']plan[\"']\s*:\s*[\"']((?:[^\"\\]|\\.)*)[\"']")
+        response['thoughts']['criticism'] = self.match_prop(message, r"[\"']criticism[\"']\s*:\s*[\"']((?:[^\"\\]|\\.)*)[\"']")
+        response['thoughts']['speak'] = self.match_prop(message, r"[\"']speak[\"']\s*:\s*[\"']((?:[^\"\\]|\\.)*)[\"']")
+        response['command']['name'] = self.match_prop(message, r"[\"']name[\"']\s*:\s*[\"']((?:[^\"\\]|\\.)*)[\"']")
+        
+        return response

--- a/src/auto_gpt_text_gen_plugin/prompt_engine.py
+++ b/src/auto_gpt_text_gen_plugin/prompt_engine.py
@@ -102,6 +102,17 @@ class PromptEngine:
         """
 
         return self.get_profile_attribute('send_as')
+    
+
+    def get_ai_chat_name(self) -> str:
+        """
+        Get the name of the AI to use when building chat messages
+        
+        Returns:
+            str: The AI's name.
+        """
+
+        return self.get_profile_attribute('ai_name')
 
 
     def get_profile_attribute(self, attribute:str, container:str = '') -> str:


### PR DESCRIPTION
- Add more debug info so fixing YAML files and wrong paths is easier
- Add a send_as and ai_name setting so when conversation strings are built, some models can follow the AI conversation better
- If models are behaving, they send the plan attribute of the response as a list, which is correct given the YAML, but Auto-GPT want's a YAML string, not an array. Auto-GPT will now always get a YAML bulleted list back.